### PR TITLE
fix: git url after siebly repo migration

### DIFF
--- a/.github/workflows/templates-readme.yml
+++ b/.github/workflows/templates-readme.yml
@@ -53,19 +53,19 @@ jobs:
       - name: Fetch and update RELATED PROJECTS template
         run: ./update-template.sh
         env:
-          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/tiagosiebler/awesome-crypto-examples/Related-projects.md
+          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/sieblyio/awesome-crypto-examples/Related-projects.md
           TEMPLATE_TAG: related_projects
 
       - name: Fetch and update CONTRIBUTIONS template
         run: ./update-template.sh
         env:
-          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/tiagosiebler/awesome-crypto-examples/Contributions-%26-Thanks.md
+          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/sieblyio/awesome-crypto-examples/Contributions-%26-Thanks.md
           TEMPLATE_TAG: contributions
 
       - name: Fetch and update STAR HISTORY template
         run: ./update-template.sh
         env:
-          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/tiagosiebler/awesome-crypto-examples/Star-History.md
+          TEMPLATE_URL: https://raw.githubusercontent.com/wiki/sieblyio/awesome-crypto-examples/Star-History.md
           TEMPLATE_TAG: star_history
 
       - name: Check for changes before running linter

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Node.js & JavaScript SDK for Binance REST APIs & WebSockets
 
-[![Build & Test](https://github.com/tiagosiebler/binance/actions/workflows/test.yml/badge.svg)](https://github.com/tiagosiebler/binance/actions/workflows/test.yml)
+[![Build & Test](https://github.com/sieblyio/binance/actions/workflows/test.yml/badge.svg)](https://github.com/sieblyio/binance/actions/workflows/test.yml)
 [![npm version](https://img.shields.io/npm/v/binance)][1]
 [![npm size](https://img.shields.io/bundlephobia/min/binance/latest)][1]
-[![users count](https://dependents.info/tiagosiebler/binance/badge?label=users)](https://dependents.info/tiagosiebler/binance)
+[![users count](https://dependents.info/sieblyio/binance/badge?label=users)](https://dependents.info/sieblyio/binance)
 [![npm downloads](https://img.shields.io/npm/dt/binance)][1]
-[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/binance)][1]
-[![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/binance/badge)](https://www.codefactor.io/repository/github/tiagosiebler/binance)
+[![last commit](https://img.shields.io/github/last-commit/sieblyio/binance)][1]
+[![CodeFactor](https://www.codefactor.io/repository/github/sieblyio/binance/badge)](https://www.codefactor.io/repository/github/sieblyio/binance)
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/binance)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sieblyio/binance)
 
 <p align="center">
   <a href="https://www.npmjs.com/package/binance">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/binance/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/binance/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/sieblyio/binance/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/sieblyio/binance/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
     </picture>
   </a>
 </p>
@@ -22,7 +22,7 @@
 [1]: https://www.npmjs.com/package/binance
 
 > [!TIP]
-> Upcoming change: As part of the [Siebly.io](https://siebly.io/) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
+> Upcoming change: As part of the [Siebly.io](https://siebly.io/) brand, this SDK is now hosted under our [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
 
 Updated & performant JavaScript & Node.js SDK for the Binance REST APIs and WebSockets:
 
@@ -102,7 +102,7 @@ Refer to the [examples](./examples) folder for implementation demos.
 
 ## Issues & Discussion
 
-- Issues? Check the [issues tab](https://github.com/tiagosiebler/binance/issues).
+- Issues? Check the [issues tab](https://github.com/sieblyio/binance/issues).
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
 - Questions about Binance APIs & WebSockets? Ask in the official [Binance API](https://t.me/binance_api_english) group on telegram.
 - Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
@@ -205,7 +205,7 @@ The MainClient covers all endpoints under the main "api\*.binance.com" subdomain
 
 Refer to the following links for a complete list of available endpoints:
 
-- [Binance Node.js & JavaScript SDK Endpoint Map](https://github.com/tiagosiebler/binance/blob/master/docs/endpointFunctionList.md)
+- [Binance Node.js & JavaScript SDK Endpoint Map](https://github.com/sieblyio/binance/blob/master/docs/endpointFunctionList.md)
 - [Binance Spot API Docs](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/general-endpoints)
 
 Start by importing the `MainClient` class. API credentials are optional, unless you plan on making private API calls. More Node.js & JavaScript examples for Binance's REST APIs & WebSockets can be found in the [examples](./examples) folder on GitHub.
@@ -474,7 +474,7 @@ wsClient.subscribe(
     'btcusdt@depth',
   ],
   // Look at the `WS_KEY_URL_MAP` for a list of values here:
-  // https://github.com/tiagosiebler/binance/blob/master/src/util/websockets/websocket-util.ts
+  // https://github.com/sieblyio/binance/blob/master/src/util/websockets/websocket-util.ts
   // "main" connects to wss://stream.binance.com:9443/stream
   // https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams
   'main',
@@ -506,7 +506,7 @@ import { WebsocketClient } from 'binance';
 
 /**
  * ETHUSDT in futures can have unusually large orderId values, sent as numbers. See this thread for more details:
- * https://github.com/tiagosiebler/binance/issues/208
+ * https://github.com/sieblyio/binance/issues/208
  *
  * If this is a problem for you, you can set a custom JSON parsing alternative using the customParseJSONFn hook injected into the WebsocketClient's constructor, as below:
  */
@@ -845,12 +845,12 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 
 ## Used By
 
-[![Repository Users Preview Image](https://dependents.info/tiagosiebler/binance/image)](https://github.com/tiagosiebler/binance/network/dependents)
+[![Repository Users Preview Image](https://dependents.info/sieblyio/binance/image)](https://github.com/sieblyio/binance/network/dependents)
 
 <!-- template_star_history -->
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,sieblyio/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&sieblyio/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
 
 <!-- template_star_history_end -->

--- a/package.json
+++ b/package.json
@@ -94,10 +94,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tiagosiebler/binance.git"
+    "url": "git+https://github.com/sieblyio/binance.git"
   },
   "bugs": {
-    "url": "https://github.com/tiagosiebler/binance/issues"
+    "url": "https://github.com/sieblyio/binance/issues"
   },
-  "homepage": "https://github.com/tiagosiebler/binance#readme"
+  "homepage": "https://github.com/sieblyio/binance#readme"
 }


### PR DESCRIPTION
Provenance statement during publish fails until this is updated.

Updates package.json repository/bugs/homepage URLs and README repo links from tiagosiebler to sieblyio after org migration.